### PR TITLE
Allowing naming of running containers

### DIFF
--- a/.release-notes/running-container-name.md
+++ b/.release-notes/running-container-name.md
@@ -1,0 +1,5 @@
+## Allowing naming of running containers
+
+Prior to this change, you could only ever start a single instance of a development environment. The name given to the running container was the short name from the Credo configuration file. If you tried to start a new instance of an environment while one was already running, you'd get an error.
+
+Both `start` and `shell` now take an optional flag `--as` to give the running container a name other than the short name from the configuration file. This allows you to have multiple instances of an environment running at the same time.

--- a/credo/cli.pony
+++ b/credo/cli.pony
@@ -31,14 +31,18 @@ primitive CLI
         CommandSpec.leaf(
           "start",
           "Starts a development environment",
-          Array[OptionSpec](),
+          [
+            OptionSpec.string("as", "Name to assign to the running environment. Default is the name of environment.", None, "")
+          ],
           [
             ArgSpec.string("name", "Name of the environment to start")
           ])?
         CommandSpec.leaf(
           "shell",
           "Opens a new shell in a development environment",
-          Array[OptionSpec](),
+          [
+            OptionSpec.string("as", "Name of the running environment. Default is the name of environment.", None, "")
+          ],
           [
             ArgSpec.string("name", "Name of the environment to open a shell in")
           ])?

--- a/credo/exec.pony
+++ b/credo/exec.pony
@@ -3,7 +3,10 @@ use @execvpe[I32](path: Pointer[U8] tag,
   envp: Pointer[Pointer[U8] tag] tag)
 
 primitive StartContainer
-  fun apply(devenv: Environment) =>
+  fun apply(devenv: Environment, running_name: String) =>
+    """
+    Starts a development environment container using the name `running_name`.
+    """
     let args: Array[String] val = recover val
       let mounts: Array[String] = []
       for m in devenv.mounts.values() do
@@ -20,7 +23,7 @@ primitive StartContainer
         "--user"
         devenv.user
         "--name"
-        devenv.name
+        running_name
         "-w"
         devenv.workdir
         "--mount"
@@ -44,13 +47,13 @@ primitive StartContainer
     @execvpe("docker".cstring(), argsp.cpointer(), varsp.cpointer())
 
 primitive OpenShell
-  fun apply(devenv: Environment) =>
+  fun apply(devenv: Environment, running_name: String) =>
     let args: Array[String] val =
       [
         "docker"
         "exec"
         "-it"
-        devenv.name
+        running_name
         devenv.shell
       ]
 

--- a/credo/main.pony
+++ b/credo/main.pony
@@ -25,19 +25,19 @@ actor Main
       | let devenvs: Array[Environment] val =>
         match cmd.fullname()
         | "credo/start" =>
-          let env_name = cmd.arg("name").string()
+          (let env_name, let running_name) = _extract_names(cmd)
           for d in devenvs.values() do
             if d.name == env_name then
-              StartContainer(d)
+              StartContainer(d, running_name)
               return
             end
           end
           env.err.print("Error: No environment " + env_name + " found")
         | "credo/shell" =>
-          let env_name = cmd.arg("name").string()
+          (let env_name, let running_name) = _extract_names(cmd)
           for d in devenvs.values() do
             if d.name == env_name then
-              OpenShell(d)
+              OpenShell(d, running_name)
               return
             end
           end
@@ -54,4 +54,10 @@ actor Main
     else
       env.err.print("Error: Unable to get config directory location")
     end
+
+  fun _extract_names(cmd: Command): (String, String) =>
+    let env_name = cmd.arg("name").string()
+    let as_string = cmd.option("as").string()
+    let running_name = if as_string != "" then as_string else env_name end
+    (env_name, running_name)
 


### PR DESCRIPTION
Prior to this change, you could only ever start a single instance of a development environment. The name given to the running container was the short name from the Credo configuration file. If you tried to start a new instance of an environment while one was already running, you'd get an error.

Both `start` and `shell` now take an optional flag `--as` to give the running container a name other than the short name from the configuration file. This allows you to have multiple instances of an environment running at the same time.