### PR TITLE
Allow alternate configuration file locations

### DIFF
--- a/.release-notes/take-config-option.md
+++ b/.release-notes/take-config-option.md
@@ -1,0 +1,3 @@
+## Allow alternate configuration file locations
+
+Credo now supports an alternate configuration file location. You can specify the location of the configuration file via the `--config` option. If `--config` is not used, Credo will default to `$HOME/.config/credo/config.json`.

--- a/credo/cli.pony
+++ b/credo/cli.pony
@@ -26,7 +26,9 @@ primitive CLI
     CommandSpec.parent(
       "credo",
       "A containerized development environment runner",
-      [],
+      [
+        OptionSpec.string("config", "Path to the configuration file.", None, "")
+      ],
       [
         CommandSpec.leaf(
           "start",

--- a/credo/config.pony
+++ b/credo/config.pony
@@ -7,12 +7,12 @@ primitive ConfigParseError
 type ConfigLoadResult is (Array[Environment] val | NoConfigFile | ConfigParseError)
 
 primitive Config
-  fun load(auth: FileAuth, config_dir: String): ConfigLoadResult =>
+  fun load(auth: FileAuth, config: String): ConfigLoadResult =>
     let caps = recover val FileCaps.>set(FileRead).>set(FileStat) end
 
     try
       with file = OpenFile(
-        FilePath(auth, config_dir + "/config.json", caps)) as File
+        FilePath(auth, config, caps)) as File
       do
         try
           let json = _get_json_config(file)?

--- a/credo/main.pony
+++ b/credo/main.pony
@@ -18,8 +18,8 @@ actor Main
         return
       end
 
-    try
-      let config_dir = AppDirs(env.vars, "credo").user_config_dir()?
+    match _extract_config_path(env.vars, cmd)
+    | let config_dir: String =>
       let config = Config.load(FileAuth(env.root), config_dir)
       match config
       | let devenvs: Array[Environment] val =>
@@ -51,8 +51,24 @@ actor Main
       | ConfigParseError =>
         env.err.print("Error: Unable to parse config file")
       end
-    else
+    | None =>
       env.err.print("Error: Unable to get config directory location")
+    end
+
+  fun _extract_config_path(
+    vars: Array[String] val,
+    cmd: Command): (String | None)
+  =>
+    try
+      let config_path = cmd.option("config").string()
+      if config_path != "" then
+        config_path
+      else
+        let dir = AppDirs(vars, "credo").user_config_dir()?
+        dir + "/" + "config.json"
+      end
+    else
+      None
     end
 
   fun _extract_names(cmd: Command): (String, String) =>


### PR DESCRIPTION
Credo now supports an alternate configuration file location. You can specify the location of the configuration file via the `--config` option. If `--config` is not used, Credo will default to `$HOME/.config/credo/config.json`.