### PR TITLE
Set Meaningful Hostname on Container Startup

### DIFF
--- a/.release-notes/issue-15.md
+++ b/.release-notes/issue-15.md
@@ -1,0 +1,5 @@
+## Set Meaningful Hostname on Container Startup
+
+When starting a container, we now pass the `--hostname` option to Docker. This sets the hostname to something meaningful to the user rather than the default Docker container ID.
+
+The hostname will use the name of the development environment or the name from the Credo `--as` option if provided.

--- a/credo/exec.pony
+++ b/credo/exec.pony
@@ -24,6 +24,8 @@ primitive StartContainer
         devenv.user
         "--name"
         running_name
+        "--hostname"
+        running_name
         "-w"
         devenv.workdir
         "--mount"


### PR DESCRIPTION
When starting a container, we now pass the `--hostname` option to Docker. This sets the hostname to something meaningful to the user rather than the default Docker container ID.

The hostname will use the name of the development environment or the name from the Credo `--as` option if provided.

Closes #15