### PR TITLE
Update Docker Image to Be Based on `scratch`

### DIFF
--- a/.release-notes/scratch-image.md
+++ b/.release-notes/scratch-image.md
@@ -1,0 +1,3 @@
+## Update Docker Image to Be Based on `scratch`
+
+Instead of including a full Alpine 3.20 environment in the Credo Docker image, we now only include the compiled Credo binary and its license file. This should shrink the image size significantly.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ WORKDIR /src/credo
 RUN make arch=x86-64 static=true linker=bfd config=release \
  && make install
 
-FROM alpine:3.20
+FROM scratch
 
 COPY --from=build /usr/local/bin/credo /usr/local/bin/credo
 COPY LICENSE /
 
-CMD credo
+ENTRYPOINT ["/usr/local/bin/credo"]


### PR DESCRIPTION
Instead of including a full Alpine 3.20 environment in the Credo Docker image, we now only include the compiled Credo binary and its license file. This should shrink the image size significantly.