### PR TITLE
Allow debuggers to run in containerized environments

### DIFF
--- a/.release-notes/allow-lldb.md
+++ b/.release-notes/allow-lldb.md
@@ -1,0 +1,3 @@
+## Allow debuggers to run in containerized environments
+
+We've added `--cap-add=SYS_PTRACE --security-opt seccomp=unconfined` as part of container startup. Debuggers like LLDB can now run in environments that Credo starts.

--- a/credo/exec.pony
+++ b/credo/exec.pony
@@ -34,6 +34,9 @@ primitive StartContainer
 
       let args2: Array[String] =
         [
+        "--cap-add=SYS_PTRACE"
+        "--security-opt"
+        "seccomp=unconfined"
         "--rm"
         "-i"
         "-t"


### PR DESCRIPTION
We've added `--cap-add=SYS_PTRACE --security-opt seccomp=unconfined` as part of container startup. Debuggers like LLDB can now run in environments that Credo starts.