### PR TITLE
Always pull image when starting a development environment

### DIFF
--- a/.release-notes/always-pull.md
+++ b/.release-notes/always-pull.md
@@ -1,0 +1,3 @@
+## Always pull image when starting a development environment
+
+When starting a development environment, the image is always pulled from the registry. This ensures that the latest version of the image is used. If the local version of the image  is up-to-date, the image is not pulled again.

--- a/credo/exec.pony
+++ b/credo/exec.pony
@@ -20,6 +20,7 @@ primitive StartContainer
         [
         "docker"
         "run"
+        "--pull=always"
         "--user"
         devenv.user
         "--name"


### PR DESCRIPTION
When starting a development environment, the image is always pulled from the registry. This ensures that the latest version of the image is used. If the local version of the image  is up-to-date, the image is not pulled again.